### PR TITLE
compatibility with Tab Groups add-on

### DIFF
--- a/src/lib/storage/session.js
+++ b/src/lib/storage/session.js
@@ -254,6 +254,7 @@ SessionStorage.prototype = {
    * @returns {Object}
    */
   _setTabData: function(tab, data) {
+    this._stopTabView(tab.ownerDocument.defaultView);
     this._store.setTabValue(
       tab,
       "tabview-tab",
@@ -293,6 +294,7 @@ SessionStorage.prototype = {
    * @returns {Object}
    */
   _setGroupsData: function(chromeWindow, data) {
+    this._stopTabView(chromeWindow);
     this._store.setWindowValue(
       chromeWindow,
       "tabview-group",
@@ -331,11 +333,26 @@ SessionStorage.prototype = {
    * @returns {Object}
    */
   _setCurrentGroupData: function(chromeWindow, data) {
+    this._stopTabView(chromeWindow);
     this._store.setWindowValue(
       chromeWindow,
       "tabview-groups",
       JSON.stringify(data)
     );
+  },
+
+  /**
+   * Deinitializes the TabView frame from the Tab Groups add-on, so that it
+   * reconstructs any changed data by us properly when it is accessed again.
+   * The _deinitFrame method only exists with that add-on enabled, and it
+   * will no-op if the frame isn't already initialized.
+   *
+   * @param {ChromeWindow} chromeWindow
+   */
+  _stopTabView: function(chromeWindow) {
+    if(chromeWindow.TabView && chromeWindow.TabView._deinitFrame) {
+      chromeWindow.TabView._deinitFrame();
+    }
   },
 
   /**


### PR DESCRIPTION
Hi Dennis,

I tweaked the sanity checks of stored data within my add-on. For instance, it rebuilds the groups bounds when this data is missing, so that it recognizes groups created by your add-on.

However this can only happen when the TabView frame is initialized. So whenever it makes any change to the groups, it has to deinitialize the frame first; hence this patch. :)

At least with this patch (and the latest dev build of my add-on, https://github.com/Quicksaver/Tab-Groups/releases/tag/v1b1) I can't reproduce the incompatibility case you described in one of your e-mails, about opening new tabs in different groups. I can create new groups, assign them tabs, and close groups from your button, and manage them correctly within my Tab Groups every step of the way.

Maybe this won't fix everything, but it definitely makes both add-ons usable at the same time. :)
