### PR TITLE
Key navigation and group selected tab saving

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const {Hotkey} = require("sdk/hotkeys");
 const {Panel} = require("sdk/panel");
 const Prefs = require("sdk/simple-prefs");
 const TabsUtils = require("sdk/tabs/utils");
+const Tabs = require("sdk/tabs");
 const {ToggleButton} = require("sdk/ui/button/toggle");
 const WindowUtils = require("sdk/window/utils");
 
@@ -14,7 +15,10 @@ const {TabManager} = require("lib/tabmanager");
 
 function TabGroups() {
   this._groupsPanel = null;
-  this._hotkey = null;
+  this._hotkeyOpen = null;
+  this._hotkeyNextGroup = null;
+  this._hotkeyPrevGroup = null;
+
   this._panelButton = null;
 
   this._tabs = new TabManager(new SessionStorage());
@@ -27,13 +31,15 @@ TabGroups.prototype = {
   init: function() {
     this.createPanelButton();
     this.createGroupsPanel();
-    this.createHotkey();
+    this.createOpenHotkey();
+    this.createNavigationHotkey();
   },
 
   bindEvents: function() {
     this.bindHotkeyPreference();
     this.bindPanelButtonEvents();
     this.bindPanelEvents();
+    this.bindTabEvents();
   },
 
   createGroupsPanel: function() {
@@ -65,7 +71,7 @@ TabGroups.prototype = {
     });
   },
 
-  createHotkey: function() {
+  createOpenHotkey: function() {
     if (!Prefs.prefs.bindPanoramaShortcut) {
       return;
     }
@@ -75,7 +81,7 @@ TabGroups.prototype = {
      * it is perfectly save to assume accel-shift-e is not used by anything
      * else.
      */
-    this._hotkey = Hotkey({
+    this._hotkeyOpen = Hotkey({
       combo: "accel-shift-e",
       onPress: () => {
         if (this._groupsPanel.isShowing) {
@@ -88,19 +94,67 @@ TabGroups.prototype = {
     });
   },
 
+  createNavigationHotkey: function() {
+    if (!Prefs.prefs.bindNavigationShortcut) {
+      return;
+    }
+
+    this._hotkeyNextGroup = Hotkey({
+      combo: "accel-`",
+      onPress: () => {
+        this._tabs.selectNextPrevGroup(
+          this._getWindow(),
+          this._getTabBrowser(),
+          1
+        );
+      }
+    });
+    this._hotkeyPrevGroup = Hotkey({
+      combo: "accel-shift-`",
+      onPress: () => {
+        this._tabs.selectNextPrevGroup(
+          this._getWindow(),
+          this._getTabBrowser(),
+          -1
+        );
+      }
+    });
+  },
+
   bindHotkeyPreference: function() {
     if (Prefs.prefs.bindPanoramaShortcut) {
-      this.createHotkey();
+      this.createOpenHotkey();
+    }
+
+    if (Prefs.prefs.bindNavigationShortcut) {
+      this.createNavigationHotkey();
     }
 
     Prefs.on("bindPanoramaShortcut", () => {
       if (Prefs.prefs.bindPanoramaShortcut) {
-        if (!this._hotkey) {
-          this.createHotkey();
+        if (!this._hotkeyOpen) {
+          this.createOpenHotkey();
         }
-      } else if (this._hotkey) {
-        this._hotkey.destroy();
-        this._hotkey = null;
+      } else if (this._hotkeyOpen) {
+        this._hotkeyOpen.destroy();
+        this._hotkeyOpen = null;
+      }
+    });
+
+    Prefs.on("bindNavigationShortcut", () => {
+      if (Prefs.prefs.bindNavigationShortcut) {
+        if (!this._hotkeyNextGroup) {
+          this.createNavigationHotkey();
+        }
+      } else {
+        if (this._hotkeyNextGroup) {
+          this._hotkeyNextGroup.destroy();
+          this._hotkeyNextGroup = null;
+        }
+        if (this._hotkeyPrevGroup) {
+          this._hotkeyPrevGroup.destroy();
+          this._hotkeyPrevGroup = null;
+        }
       }
     });
   },
@@ -132,6 +186,15 @@ TabGroups.prototype = {
     this._groupsPanel.port.on("Group:Select", this.onGroupSelect.bind(this));
     this._groupsPanel.port.on("Tab:Select", this.onTabSelect.bind(this));
     this._groupsPanel.port.on("UI:Resize", this.resizePanel.bind(this));
+  },
+
+  bindTabEvents: function() {
+    Tabs.on("activate", () => {
+      this._tabs.updateCurrentSelectedTab(this._getWindow());
+    });
+    Tabs.on("open", () => {
+      this._tabs.updateCurrentSelectedTab(this._getWindow());
+    });
   },
 
   refreshUi: function() {

--- a/src/lib/storage/session.js
+++ b/src/lib/storage/session.js
@@ -36,7 +36,8 @@ SessionStorage.prototype = {
       groups.push({
         active: group.id == currentGroup.activeGroupId,
         id: group.id,
-        title: group.title
+        title: group.title,
+        selectedIndex: group.selectedIndex
       });
     }
 
@@ -52,6 +53,7 @@ SessionStorage.prototype = {
   getTabs: function(chromeWindow) {
     let browser = TabsUtils.getTabBrowser(chromeWindow);
     let tabs = [];
+    let currentGroup = this.getCurrentGroup(chromeWindow);
 
     for (let tabIndex = 0; tabIndex < browser.tabs.length; tabIndex++) {
       let tab = browser.tabs[tabIndex];
@@ -62,7 +64,7 @@ SessionStorage.prototype = {
         continue;
       }
 
-      let group = this.getCurrentGroup(chromeWindow);
+      let group = currentGroup;
       if (tabData && tabData.groupID) {
         group = tabData.groupID;
       } else {
@@ -172,7 +174,8 @@ SessionStorage.prototype = {
     let groupID = this.getNextGroupID(chromeWindow);
     groups[groupID] = {
       id: groupID,
-      title: title
+      title: title,
+      selectedIndex: 0
     };
 
     let currentGroups = this._getCurrentGroupData(chromeWindow);
@@ -232,6 +235,34 @@ SessionStorage.prototype = {
     let groupsData = this._getGroupsData(chromeWindow);
     groupsData[groupID].title = title;
     this._setGroupsData(chromeWindow, groupsData);
+  },
+
+  /**
+   * Get the selected tab index for a group.
+   *
+   * @param {ChromeWindow} chromeWindow
+   * @param {Number} groupID - the groupID
+   */
+  getGroupSelectedIndex: function(chromeWindow, groupID) {
+    let groupsData = this._getGroupsData(chromeWindow);
+    let currentGroup = groupsData[groupID];
+    return currentGroup == null ? 0 : currentGroup.selectedIndex;
+  },
+
+  /**
+   * Set the selected tab index for a group.
+   *
+   * @param {ChromeWindow} chromeWindow
+   * @param {Number} groupID - the groupID
+   * @param {Number} index - the new selected index
+   */
+  setGroupSelectedIndex: function(chromeWindow, groupID, index) {
+    let groupsData = this._getGroupsData(chromeWindow);
+    let currentGroup = groupsData[groupID];
+    if (currentGroup != null) {
+      currentGroup.selectedIndex = index;
+      this._setGroupsData(chromeWindow, groupsData);
+    }
   },
 
   /**

--- a/src/lib/tabmanager.js
+++ b/src/lib/tabmanager.js
@@ -54,6 +54,10 @@ TabManager.prototype = {
       return;
     }
 
+    this.updateCurrentSelectedTab(chromeWindow);
+
+    let lastSelected = this._storage.getGroupSelectedIndex(chromeWindow, groupID);
+
     let tabs = this._storage.getTabIndexesByGroup(tabBrowser, groupID);
 
     let selectedTab;
@@ -64,7 +68,7 @@ TabManager.prototype = {
     } else if (tabIndex) {
       selectedTab = tabBrowser.tabs[tabIndex];
     } else {
-      selectedTab = tabBrowser.tabs[tabs[tabIndex]];
+      selectedTab = tabBrowser.tabs[lastSelected < tabs.length ? tabs[lastSelected] : tabs[0]];
     }
 
     this._storage.setCurrentGroup(chromeWindow, groupID);
@@ -73,6 +77,49 @@ TabManager.prototype = {
     tabBrowser.showOnlyTheseTabs(tabs.map((tab) => {
       return tabBrowser.tabs[tab];
     }));
+  },
+
+  /**
+   * Selects the next or previous group in the list
+   *
+   * @param {ChromeWindow} chromeWindow
+   * @param {Number} direction
+   */
+  selectNextPrevGroup: function(chromeWindow, tabBrowser, direction) {
+    let currentGroup = this._storage.getCurrentGroup(chromeWindow);
+    let groups = this._storage.getGroups(chromeWindow);
+    if (groups.length == 0) {
+      return;
+    }
+
+    let index = groups.findIndex((group) => {
+      return group.id == currentGroup;
+    });
+
+    if (index == -1) {
+      return;
+    }
+
+    index = (index + direction + groups.length) % groups.length;
+    this.selectGroup(chromeWindow, tabBrowser, groups[index].id);
+  },
+
+  /**
+   * Updates the currently selected index for the given window
+   *
+   * @param {ChromeWindow} chromeWindow
+   */
+  updateCurrentSelectedTab: function(chromeWindow) {
+    let tabs = this._storage.getTabs(chromeWindow);
+    let curtab = tabs.find((tab) => {
+      return tab.active;
+    });
+
+    let curindex = tabs.filter((tab) => {
+      return tab.group == curtab.group;
+    }).indexOf(curtab);
+
+    this._storage.setGroupSelectedIndex(chromeWindow, curtab.group, curindex);
   },
 
   /**

--- a/src/package.json
+++ b/src/package.json
@@ -17,6 +17,12 @@
       "title": "Listen to Ctrl/Cmd-Shift-E",
       "type": "bool",
       "value": true
+    },
+    {
+      "name": "bindNavigationShortcut",
+      "title": "Listen to Ctrl/Cmd-~ and Ctrl/Cmd-Shift-~",
+      "type": "bool",
+      "value": true
     }
   ]
 }


### PR DESCRIPTION
The first commit adds Ctrl-~ and Ctrl-Shift-~ hotkeys for navigating between groups, and the second one saves the index of the selected tab in each group so that the last tab is selected when the group is navigated.

These behave the same as the original panorama feature.
