### PR TITLE
Stop click events in the group name <input> from switching groups

### DIFF
--- a/src/data/components/group.js
+++ b/src/data/components/group.js
@@ -36,6 +36,9 @@ const Group = React.createClass({
           onChange: (event) => {
             this.setState({newTitle: event.target.value});
           },
+          onClick: (event) => {
+            event.stopPropagation();
+          },
           onKeyUp: this.handleGroupTitleInputKey
         }
       );


### PR DESCRIPTION
Fixes #25
