### PR TITLE
Listen to `control` instead of `accel` for tab group switching shortcut

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ TabGroups.prototype = {
     }
 
     this._hotkeyNextGroup = Hotkey({
-      combo: "accel-`",
+      combo: "control-`",
       onPress: () => {
         this._tabs.selectNextPrevGroup(
           this._getWindow(),
@@ -114,7 +114,7 @@ TabGroups.prototype = {
       }
     });
     this._hotkeyPrevGroup = Hotkey({
-      combo: "accel-shift-`",
+      combo: "control-shift-`",
       onPress: () => {
         this._tabs.selectNextPrevGroup(
           this._getWindow(),

--- a/src/package.json
+++ b/src/package.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "bindNavigationShortcut",
-      "title": "Listen to Ctrl/Cmd-~ and Ctrl/Cmd-Shift-~",
+      "title": "Listen to Ctrl-~ and Ctrl-Shift-~",
       "type": "bool",
       "value": true
     },


### PR DESCRIPTION
The tab group switching shortcuts don't work on OSX since `Cmd-~` and `Cmd-Shift-~` are system shortcuts for window switching. Switching the shortcuts to explicitly use `control` instead of `accel` allows them to work on OSX and remain the same on other OSs.